### PR TITLE
Fixed typo in contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ class About extends Me
         ];
     }
 
-    public function getContancts(): array
+    public function getContacts(): array
     {
         return [
             'Email'    => 'helldar@dragon-code.pro',


### PR DESCRIPTION
There was a typo in the `getContacts()` function 😉