### PR TITLE
Improve profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,59 @@
-# Andrey Helldar
+# Hi, I'm Andrey Helldar 👋
 
-Open-source maintainer working with Laravel and PHP.
+I'm an open-source maintainer focused on the Laravel and PHP ecosystem. I create
+and maintain developer tools, localization packages, automation utilities, and
+services that make day-to-day development smoother.
 
-I create and maintain packages, localization tools, automation utilities, and
-services for Laravel and PHP projects.
+> It's never too late to get better.
 
-## Organizations and Projects
+I build and maintain projects across [The Dragon Code](https://github.com/TheDragonCode),
+[Laravel Lang](https://github.com/Laravel-Lang), [Package Wizard](https://github.com/package-wizard),
+[Cashbox for Laravel](https://github.com/cashbox-laravel), and [Kvede Bot](https://kvede.com).
 
-- [The Dragon Code](https://github.com/TheDragonCode) - Laravel and PHP packages,
-  developer tools, and services.
-- [Laravel Lang](https://github.com/Laravel-Lang) - localization files and tools
-  for Laravel ecosystem products and third-party packages.
-- [Package Wizard](https://github.com/package-wizard) - tools for starting new
-  packages and applications with less manual setup.
-- [Cashbox for Laravel](https://github.com/cashbox-laravel) - billing and payment
-  verification tools for Laravel applications.
-- [Kvede Bot](https://kvede.com) - Telegram chat management with analytics.
-- [Volunteers CRM](https://github.com/volunteers-crm) - tools for volunteer teams
-  to organize work and manage tasks.
+## What I Build
 
-## Areas of Work
-
-- Laravel and PHP packages.
-- Localization infrastructure for Laravel projects.
+- Laravel and PHP packages with expressive APIs.
+- Localization infrastructure for Laravel ecosystem products and third-party packages.
 - Deployment, cache, routing, database, telemetry, and release automation tools.
-- Telegram chat management, payment workflows, and volunteer coordination tools.
+- Products for Telegram chat management, payment workflows, and volunteer coordination.
 
-## Selected Packages
+## Projects I Created
 
-| Project | Purpose |
+- 🍀 [Kvede Bot](https://kvede.com) - Telegram chat management with analytics capabilities.
+- 🐉 [The Dragon Code](https://github.com/TheDragonCode) - a collection of developer-focused packages and services.
+- 🪄 [Package Wizard](https://github.com/package-wizard) - a faster way to start new packages and applications without repetitive setup.
+- 💵 [Cashbox for Laravel](https://github.com/cashbox-laravel) - billing and payment verification tools for Laravel applications.
+- 🗺️ [Volunteers CRM](https://github.com/volunteers-crm) - tools that help volunteer teams organize work and manage tasks.
+
+I also lead and maintain [Laravel Lang](https://github.com/Laravel-Lang), a localization
+project for Laravel ecosystem products and third-party packages.
+
+## Featured Work
+
+| Project | Focus |
 | --- | --- |
 | [Deploy Operations](https://github.com/TheDragonCode/laravel-deploy-operations) | Run deployment operations from Laravel applications. |
 | [Laravel Lang Publisher](https://github.com/Laravel-Lang/publisher) | Publish and manage Laravel localization assets. |
 | [Database Data Dumper](https://github.com/TheDragonCode/laravel-data-dumper) | Include selected table data when running `php artisan schema:dump`. |
-| [Smart Cache](https://github.com/TheDragonCode/laravel-cache) | Helpers for working with cache. |
+| [Smart Cache](https://github.com/TheDragonCode/laravel-cache) | Improved helpers for working with cache. |
 | [GitHub Notifications](https://github.com/TheDragonCode/github-notifications) | Utilities for working with GitHub notifications. |
 | [HTTP Logger](https://github.com/TheDragonCode/laravel-http-logger) | HTTP request and response logging for Laravel applications. |
-| [JSON Response](https://github.com/TheDragonCode/laravel-json-response) | JSON response customization for REST APIs. |
+| [JSON Response](https://github.com/TheDragonCode/laravel-json-response) | Consistent JSON response customization for REST APIs. |
 | [Migrate DB](https://github.com/TheDragonCode/migrate-db) | Move data from one database to another. |
-| [Pretty Routes](https://github.com/TheDragonCode/pretty-routes) | Route listing, filtering, and sorting for Laravel. |
+| [Pretty Routes](https://github.com/TheDragonCode/pretty-routes) | Convenient route listing, filtering, and sorting for Laravel. |
 | [Which Color](https://github.com/TheDragonCode/which-color) | Detect readable foreground colors for a given background. |
 | [GitHub Preview Generator](https://github.com/TheDragonCode/github-preview-updater) | Generate and update repository preview images. |
 
+This is not a complete list of projects, but it is a good place to start.
+
+Working on open source is one of my great joys, and I want to keep doing it as
+much and for as long as I possibly can. I hope something here is useful to you.
+Thanks for visiting!
+
 ## Support
 
-You can support my open-source work here:
+If anything I built is useful to you or your company, please consider supporting
+my open-source work:
 
 - [Boosty](https://boosty.to/dragon-code)
 - [DonationAlerts](https://www.donationalerts.com/r/dragon_code)

--- a/README.md
+++ b/README.md
@@ -1,37 +1,60 @@
-**Hi there** 👋
+# Hi, I'm Andrey Helldar 👋
 
-I'm [Andrey Helldar](https://dragon-code.pro), open-source maintainer and creator of
-[Dragon Code](https://github.com/TheDragonCode), [Kvede Bot](https://kvede.com) for Telegram, [Package Wizard](https://github.com/package-wizard)
-and [Cashbox for Laravel](https://github.com/cashbox-laravel).
-I'm also the main developer on the [Laravel-Lang](https://github.com/Laravel-Lang) project.
-I also build, maintain and release all packages.
+I'm an open-source maintainer focused on the Laravel and PHP ecosystem. I create
+and maintain developer tools, localization packages, automation utilities, and
+services that make day-to-day development smoother.
 
-Projects of which I'm the creator:
+> It's never too late to get better.
 
-- 🍀 [Kvede Bot](https://kvede.com) is a simple Telegram chat management with analytics capabilities.
-- 🐉 [The Dragon Code](https://github.com/TheDragonCode) is a core project containing many useful software products for developers.
-- 🪄 [Package Wizard](https://github.com/package-wizard) allows you to quickly and easily start developing packages and applications without the hassle of initial customization.
-- 💵 [Cashbox for Laravel](https://github.com/cashbox-laravel) provides an expressive and user-friendly interface for managing billing and payment verification services.
-- 🗺️ [Volunteers CRM](https://github.com/volunteers-crm) allows volunteers to quickly organize the management of their work and simplifies the management of tasks.
+I build and maintain projects across [The Dragon Code](https://github.com/TheDragonCode),
+[Laravel Lang](https://github.com/Laravel-Lang), [Package Wizard](https://github.com/package-wizard),
+[Cashbox for Laravel](https://github.com/cashbox-laravel), and [Kvede Bot](https://kvede.com).
 
-Among all my projects, I highlight the following:
+## What I Build
 
-- [Deploy Operations](https://github.com/TheDragonCode/laravel-deploy-operations)
-- [Cashbox for Laravel](https://github.com/cashbox-laravel)
-- [Database Data Dumper](https://github.com/TheDragonCode/laravel-data-dumper)
-- [Lang Publisher](https://github.com/Laravel-Lang/publisher)
-- [Smart Cache](https://github.com/TheDragonCode/laravel-cache)
-- [GitHub Notifications](https://github.com/TheDragonCode/github-notifications)
-- [HTTP Logger](https://github.com/TheDragonCode/laravel-http-logger)
-- [JSON Response](https://github.com/TheDragonCode/laravel-json-response)
-- [Migrate DB](https://github.com/TheDragonCode/migrate-db)
-- [Pretty Routes](https://github.com/TheDragonCode/pretty-routes)
-- [Which Color](https://github.com/TheDragonCode/which-color)
-- [GitHub Preview Generator](https://github.com/TheDragonCode/github-preview-updater)
+- Laravel and PHP packages with expressive APIs.
+- Localization infrastructure for Laravel ecosystem products and third-party packages.
+- Deployment, cache, routing, database, telemetry, and release automation tools.
+- Products for Telegram chat management, payment workflows, and volunteer coordination.
 
-But this isn't a complete list of really cool projects 😎
+## Projects I Created
 
-Working on open-source is my great joy in life and I want to be able to do that as much and as long as I possible can. I hope you like what I work on and that some of it is useful to you. Thanks for visiting!
+- 🍀 [Kvede Bot](https://kvede.com) - Telegram chat management with analytics capabilities.
+- 🐉 [The Dragon Code](https://github.com/TheDragonCode) - a collection of developer-focused packages and services.
+- 🪄 [Package Wizard](https://github.com/package-wizard) - a faster way to start new packages and applications without repetitive setup.
+- 💵 [Cashbox for Laravel](https://github.com/cashbox-laravel) - billing and payment verification tools for Laravel applications.
+- 🗺️ [Volunteers CRM](https://github.com/volunteers-crm) - tools that help volunteer teams organize work and manage tasks.
 
-If you found anything that I built useful for you or your company, consider sponsoring me on
-[Boosty](https://boosty.to/dragon-code) and [YooMoney](https://yoomoney.ru/to/410012608840929) ❤️
+I also lead and maintain [Laravel Lang](https://github.com/Laravel-Lang), a localization
+project for Laravel ecosystem products and third-party packages.
+
+## Featured Work
+
+| Project | Focus |
+| --- | --- |
+| [Deploy Operations](https://github.com/TheDragonCode/laravel-deploy-operations) | Run deployment operations from Laravel applications. |
+| [Laravel Lang Publisher](https://github.com/Laravel-Lang/publisher) | Publish and manage Laravel localization assets. |
+| [Database Data Dumper](https://github.com/TheDragonCode/laravel-data-dumper) | Include selected table data when running `php artisan schema:dump`. |
+| [Smart Cache](https://github.com/TheDragonCode/laravel-cache) | Improved helpers for working with cache. |
+| [GitHub Notifications](https://github.com/TheDragonCode/github-notifications) | Utilities for working with GitHub notifications. |
+| [HTTP Logger](https://github.com/TheDragonCode/laravel-http-logger) | HTTP request and response logging for Laravel applications. |
+| [JSON Response](https://github.com/TheDragonCode/laravel-json-response) | Consistent JSON response customization for REST APIs. |
+| [Migrate DB](https://github.com/TheDragonCode/migrate-db) | Move data from one database to another. |
+| [Pretty Routes](https://github.com/TheDragonCode/pretty-routes) | Convenient route listing, filtering, and sorting for Laravel. |
+| [Which Color](https://github.com/TheDragonCode/which-color) | Detect readable foreground colors for a given background. |
+| [GitHub Preview Generator](https://github.com/TheDragonCode/github-preview-updater) | Generate and update repository preview images. |
+
+This is not a complete list of projects, but it is a good place to start.
+
+Working on open source is one of my great joys, and I want to keep doing it as
+much and for as long as I possibly can. I hope something here is useful to you.
+Thanks for visiting!
+
+## Support
+
+If anything I built is useful to you or your company, please consider supporting
+my open-source work:
+
+- [Boosty](https://boosty.to/dragon-code)
+- [DonationAlerts](https://www.donationalerts.com/r/dragon_code)
+- [YooMoney](https://yoomoney.ru/to/410012608840929)

--- a/README.md
+++ b/README.md
@@ -1,59 +1,50 @@
-# Hi, I'm Andrey Helldar 👋
+# Andrey Helldar
 
-I'm an open-source maintainer focused on the Laravel and PHP ecosystem. I create
-and maintain developer tools, localization packages, automation utilities, and
-services that make day-to-day development smoother.
+Open-source maintainer working with Laravel and PHP.
 
-> It's never too late to get better.
+I create and maintain packages, localization tools, automation utilities, and
+services for Laravel and PHP projects.
 
-I build and maintain projects across [The Dragon Code](https://github.com/TheDragonCode),
-[Laravel Lang](https://github.com/Laravel-Lang), [Package Wizard](https://github.com/package-wizard),
-[Cashbox for Laravel](https://github.com/cashbox-laravel), and [Kvede Bot](https://kvede.com).
+## Organizations and Projects
 
-## What I Build
+- [The Dragon Code](https://github.com/TheDragonCode) - Laravel and PHP packages,
+  developer tools, and services.
+- [Laravel Lang](https://github.com/Laravel-Lang) - localization files and tools
+  for Laravel ecosystem products and third-party packages.
+- [Package Wizard](https://github.com/package-wizard) - tools for starting new
+  packages and applications with less manual setup.
+- [Cashbox for Laravel](https://github.com/cashbox-laravel) - billing and payment
+  verification tools for Laravel applications.
+- [Kvede Bot](https://kvede.com) - Telegram chat management with analytics.
+- [Volunteers CRM](https://github.com/volunteers-crm) - tools for volunteer teams
+  to organize work and manage tasks.
 
-- Laravel and PHP packages with expressive APIs.
-- Localization infrastructure for Laravel ecosystem products and third-party packages.
+## Areas of Work
+
+- Laravel and PHP packages.
+- Localization infrastructure for Laravel projects.
 - Deployment, cache, routing, database, telemetry, and release automation tools.
-- Products for Telegram chat management, payment workflows, and volunteer coordination.
+- Telegram chat management, payment workflows, and volunteer coordination tools.
 
-## Projects I Created
+## Selected Packages
 
-- 🍀 [Kvede Bot](https://kvede.com) - Telegram chat management with analytics capabilities.
-- 🐉 [The Dragon Code](https://github.com/TheDragonCode) - a collection of developer-focused packages and services.
-- 🪄 [Package Wizard](https://github.com/package-wizard) - a faster way to start new packages and applications without repetitive setup.
-- 💵 [Cashbox for Laravel](https://github.com/cashbox-laravel) - billing and payment verification tools for Laravel applications.
-- 🗺️ [Volunteers CRM](https://github.com/volunteers-crm) - tools that help volunteer teams organize work and manage tasks.
-
-I also lead and maintain [Laravel Lang](https://github.com/Laravel-Lang), a localization
-project for Laravel ecosystem products and third-party packages.
-
-## Featured Work
-
-| Project | Focus |
+| Project | Purpose |
 | --- | --- |
 | [Deploy Operations](https://github.com/TheDragonCode/laravel-deploy-operations) | Run deployment operations from Laravel applications. |
 | [Laravel Lang Publisher](https://github.com/Laravel-Lang/publisher) | Publish and manage Laravel localization assets. |
 | [Database Data Dumper](https://github.com/TheDragonCode/laravel-data-dumper) | Include selected table data when running `php artisan schema:dump`. |
-| [Smart Cache](https://github.com/TheDragonCode/laravel-cache) | Improved helpers for working with cache. |
+| [Smart Cache](https://github.com/TheDragonCode/laravel-cache) | Helpers for working with cache. |
 | [GitHub Notifications](https://github.com/TheDragonCode/github-notifications) | Utilities for working with GitHub notifications. |
 | [HTTP Logger](https://github.com/TheDragonCode/laravel-http-logger) | HTTP request and response logging for Laravel applications. |
-| [JSON Response](https://github.com/TheDragonCode/laravel-json-response) | Consistent JSON response customization for REST APIs. |
+| [JSON Response](https://github.com/TheDragonCode/laravel-json-response) | JSON response customization for REST APIs. |
 | [Migrate DB](https://github.com/TheDragonCode/migrate-db) | Move data from one database to another. |
-| [Pretty Routes](https://github.com/TheDragonCode/pretty-routes) | Convenient route listing, filtering, and sorting for Laravel. |
+| [Pretty Routes](https://github.com/TheDragonCode/pretty-routes) | Route listing, filtering, and sorting for Laravel. |
 | [Which Color](https://github.com/TheDragonCode/which-color) | Detect readable foreground colors for a given background. |
 | [GitHub Preview Generator](https://github.com/TheDragonCode/github-preview-updater) | Generate and update repository preview images. |
 
-This is not a complete list of projects, but it is a good place to start.
-
-Working on open source is one of my great joys, and I want to keep doing it as
-much and for as long as I possibly can. I hope something here is useful to you.
-Thanks for visiting!
-
 ## Support
 
-If anything I built is useful to you or your company, please consider supporting
-my open-source work:
+You can support my open-source work here:
 
 - [Boosty](https://boosty.to/dragon-code)
 - [DonationAlerts](https://www.donationalerts.com/r/dragon_code)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# Hi, I'm Andrey Helldar 👋
+# Andrey Helldar
 
 I'm an open-source maintainer focused on the Laravel and PHP ecosystem. I create
 and maintain developer tools, localization packages, automation utilities, and
-services that make day-to-day development smoother.
-
-> It's never too late to get better.
+services for Laravel and PHP projects.
 
 I build and maintain projects across [The Dragon Code](https://github.com/TheDragonCode),
 [Laravel Lang](https://github.com/Laravel-Lang), [Package Wizard](https://github.com/package-wizard),
@@ -12,18 +10,18 @@ I build and maintain projects across [The Dragon Code](https://github.com/TheDra
 
 ## What I Build
 
-- Laravel and PHP packages with expressive APIs.
+- Laravel and PHP packages.
 - Localization infrastructure for Laravel ecosystem products and third-party packages.
 - Deployment, cache, routing, database, telemetry, and release automation tools.
-- Products for Telegram chat management, payment workflows, and volunteer coordination.
+- Tools for Telegram chat management, payment workflows, and volunteer coordination.
 
 ## Projects I Created
 
-- 🍀 [Kvede Bot](https://kvede.com) - Telegram chat management with analytics capabilities.
-- 🐉 [The Dragon Code](https://github.com/TheDragonCode) - a collection of developer-focused packages and services.
-- 🪄 [Package Wizard](https://github.com/package-wizard) - a faster way to start new packages and applications without repetitive setup.
-- 💵 [Cashbox for Laravel](https://github.com/cashbox-laravel) - billing and payment verification tools for Laravel applications.
-- 🗺️ [Volunteers CRM](https://github.com/volunteers-crm) - tools that help volunteer teams organize work and manage tasks.
+- [Kvede Bot](https://kvede.com) - Telegram chat management with analytics capabilities.
+- [The Dragon Code](https://github.com/TheDragonCode) - developer-focused packages and services.
+- [Package Wizard](https://github.com/package-wizard) - tools for starting new packages and applications with less manual setup.
+- [Cashbox for Laravel](https://github.com/cashbox-laravel) - billing and payment verification tools for Laravel applications.
+- [Volunteers CRM](https://github.com/volunteers-crm) - tools for volunteer teams to organize work and manage tasks.
 
 I also lead and maintain [Laravel Lang](https://github.com/Laravel-Lang), a localization
 project for Laravel ecosystem products and third-party packages.
@@ -35,25 +33,20 @@ project for Laravel ecosystem products and third-party packages.
 | [Deploy Operations](https://github.com/TheDragonCode/laravel-deploy-operations) | Run deployment operations from Laravel applications. |
 | [Laravel Lang Publisher](https://github.com/Laravel-Lang/publisher) | Publish and manage Laravel localization assets. |
 | [Database Data Dumper](https://github.com/TheDragonCode/laravel-data-dumper) | Include selected table data when running `php artisan schema:dump`. |
-| [Smart Cache](https://github.com/TheDragonCode/laravel-cache) | Improved helpers for working with cache. |
+| [Smart Cache](https://github.com/TheDragonCode/laravel-cache) | Helpers for working with cache. |
 | [GitHub Notifications](https://github.com/TheDragonCode/github-notifications) | Utilities for working with GitHub notifications. |
 | [HTTP Logger](https://github.com/TheDragonCode/laravel-http-logger) | HTTP request and response logging for Laravel applications. |
-| [JSON Response](https://github.com/TheDragonCode/laravel-json-response) | Consistent JSON response customization for REST APIs. |
+| [JSON Response](https://github.com/TheDragonCode/laravel-json-response) | JSON response customization for REST APIs. |
 | [Migrate DB](https://github.com/TheDragonCode/migrate-db) | Move data from one database to another. |
-| [Pretty Routes](https://github.com/TheDragonCode/pretty-routes) | Convenient route listing, filtering, and sorting for Laravel. |
+| [Pretty Routes](https://github.com/TheDragonCode/pretty-routes) | Route listing, filtering, and sorting for Laravel. |
 | [Which Color](https://github.com/TheDragonCode/which-color) | Detect readable foreground colors for a given background. |
 | [GitHub Preview Generator](https://github.com/TheDragonCode/github-preview-updater) | Generate and update repository preview images. |
 
-This is not a complete list of projects, but it is a good place to start.
-
-Working on open source is one of my great joys, and I want to keep doing it as
-much and for as long as I possibly can. I hope something here is useful to you.
-Thanks for visiting!
+This is not a complete list of projects.
 
 ## Support
 
-If anything I built is useful to you or your company, please consider supporting
-my open-source work:
+Support links:
 
 - [Boosty](https://boosty.to/dragon-code)
 - [DonationAlerts](https://www.donationalerts.com/r/dragon_code)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ I'm an open-source maintainer focused on the Laravel and PHP ecosystem. I create
 and maintain developer tools, localization packages, automation utilities, and
 services that make day-to-day development smoother.
 
-> It's never too late to get better.
-
 I build and maintain projects across [The Dragon Code](https://github.com/TheDragonCode),
 [Laravel Lang](https://github.com/Laravel-Lang), [Package Wizard](https://github.com/package-wizard),
 [Cashbox for Laravel](https://github.com/cashbox-laravel), and [Kvede Bot](https://kvede.com).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Andrey Helldar
+# Hi, I'm Andrey Helldar 👋
 
 I'm an open-source maintainer focused on the Laravel and PHP ecosystem. I create
 and maintain developer tools, localization packages, automation utilities, and
-services for Laravel and PHP projects.
+services that make day-to-day development smoother.
+
+> It's never too late to get better.
 
 I build and maintain projects across [The Dragon Code](https://github.com/TheDragonCode),
 [Laravel Lang](https://github.com/Laravel-Lang), [Package Wizard](https://github.com/package-wizard),
@@ -10,18 +12,18 @@ I build and maintain projects across [The Dragon Code](https://github.com/TheDra
 
 ## What I Build
 
-- Laravel and PHP packages.
+- Laravel and PHP packages with expressive APIs.
 - Localization infrastructure for Laravel ecosystem products and third-party packages.
 - Deployment, cache, routing, database, telemetry, and release automation tools.
-- Tools for Telegram chat management, payment workflows, and volunteer coordination.
+- Products for Telegram chat management, payment workflows, and volunteer coordination.
 
 ## Projects I Created
 
-- [Kvede Bot](https://kvede.com) - Telegram chat management with analytics capabilities.
-- [The Dragon Code](https://github.com/TheDragonCode) - developer-focused packages and services.
-- [Package Wizard](https://github.com/package-wizard) - tools for starting new packages and applications with less manual setup.
-- [Cashbox for Laravel](https://github.com/cashbox-laravel) - billing and payment verification tools for Laravel applications.
-- [Volunteers CRM](https://github.com/volunteers-crm) - tools for volunteer teams to organize work and manage tasks.
+- 🍀 [Kvede Bot](https://kvede.com) - Telegram chat management with analytics capabilities.
+- 🐉 [The Dragon Code](https://github.com/TheDragonCode) - a collection of developer-focused packages and services.
+- 🪄 [Package Wizard](https://github.com/package-wizard) - a faster way to start new packages and applications without repetitive setup.
+- 💵 [Cashbox for Laravel](https://github.com/cashbox-laravel) - billing and payment verification tools for Laravel applications.
+- 🗺️ [Volunteers CRM](https://github.com/volunteers-crm) - tools that help volunteer teams organize work and manage tasks.
 
 I also lead and maintain [Laravel Lang](https://github.com/Laravel-Lang), a localization
 project for Laravel ecosystem products and third-party packages.
@@ -33,20 +35,25 @@ project for Laravel ecosystem products and third-party packages.
 | [Deploy Operations](https://github.com/TheDragonCode/laravel-deploy-operations) | Run deployment operations from Laravel applications. |
 | [Laravel Lang Publisher](https://github.com/Laravel-Lang/publisher) | Publish and manage Laravel localization assets. |
 | [Database Data Dumper](https://github.com/TheDragonCode/laravel-data-dumper) | Include selected table data when running `php artisan schema:dump`. |
-| [Smart Cache](https://github.com/TheDragonCode/laravel-cache) | Helpers for working with cache. |
+| [Smart Cache](https://github.com/TheDragonCode/laravel-cache) | Improved helpers for working with cache. |
 | [GitHub Notifications](https://github.com/TheDragonCode/github-notifications) | Utilities for working with GitHub notifications. |
 | [HTTP Logger](https://github.com/TheDragonCode/laravel-http-logger) | HTTP request and response logging for Laravel applications. |
-| [JSON Response](https://github.com/TheDragonCode/laravel-json-response) | JSON response customization for REST APIs. |
+| [JSON Response](https://github.com/TheDragonCode/laravel-json-response) | Consistent JSON response customization for REST APIs. |
 | [Migrate DB](https://github.com/TheDragonCode/migrate-db) | Move data from one database to another. |
-| [Pretty Routes](https://github.com/TheDragonCode/pretty-routes) | Route listing, filtering, and sorting for Laravel. |
+| [Pretty Routes](https://github.com/TheDragonCode/pretty-routes) | Convenient route listing, filtering, and sorting for Laravel. |
 | [Which Color](https://github.com/TheDragonCode/which-color) | Detect readable foreground colors for a given background. |
 | [GitHub Preview Generator](https://github.com/TheDragonCode/github-preview-updater) | Generate and update repository preview images. |
 
-This is not a complete list of projects.
+This is not a complete list of projects, but it is a good place to start.
+
+Working on open source is one of my great joys, and I want to keep doing it as
+much and for as long as I possibly can. I hope something here is useful to you.
+Thanks for visiting!
 
 ## Support
 
-Support links:
+If anything I built is useful to you or your company, please consider supporting
+my open-source work:
 
 - [Boosty](https://boosty.to/dragon-code)
 - [DonationAlerts](https://www.donationalerts.com/r/dragon_code)


### PR DESCRIPTION
## Summary
- Rework the profile intro to clearly describe the open-source focus in Laravel/PHP tooling, localization, automation, and related services.
- Organize the README into clearer sections for focus areas, created projects, featured work, and support links.
- Add DonationAlerts from .github/FUNDING.yml to the support section and clean up wording/grammar.

## Verification
- Ran git diff --check.

Git emitted only the existing Windows line-ending warning for README.md.